### PR TITLE
ExcludeMouseTracking as marker component to opt-out a camera from mouse tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_mouse_tracking_plugin"
 description = "A plugin for effortless mouse tracking in the bevy game engine."
-version = "0.3.0"
+version = "0.3.1"
 authors = ["JoJoJet <joe102000@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ Note that [`MousePos`] and [`MousePosWorld`] will no longer be accessible as glo
 If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the [`ExcludeMouseTracking`] component.
 
 ```rust
-commands.spawn_bundle(Camera2dBundle::default())
-    .insert(ExcludeMouseTracking);
+    commands.spawn_bundle(Camera2dBundle::default())
+        .insert(ExcludeMouseTracking);
 ```
 
 This camera will not have a [`MousePos`] or a [`MousePosWorld`], as it is completely excluded from mouse tracking.
 
-One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::projection::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
+One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
 
 ```text
 thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:159:50
@@ -166,12 +166,10 @@ thread 'main' panicked at 'only orthographic cameras are supported -- consider a
 To get around this, you may choose to have the camera opt-out.
 
 ```rust
-commands
-    .spawn_bundle(Camera2dBundle {
-        projection: MyCustomProjection,
+    commands.spawn_bundle(Camera3dBundle {
+        projection: Projection::from(PerspectiveProjection::default()),
         ..default()
-    })
-    .insert(ExcludeMouseTracking);
+    }).insert(ExcludeMouseTracking);
 ```
 
 ## Mouse motion

--- a/README.md
+++ b/README.md
@@ -97,14 +97,6 @@ the values of the [`MousePos`] and [`MousePosWorld`] resources. Let's take the p
     commands.spawn_bundle(Camera3dBundle::default());
 ```
 
-If you have multiple cameras with [`MainCamera`], the app panics:
-
-```text
-thread 'main' panicked at 'only one camera may be marked with the MainCamera component', src\mouse_pos.rs:209:17
-```
-
-You should only have a single [`MainCamera`] in your app.
-
 ### Queries
 
 If you want to get mouse tracking information relative to each camera individually,

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ fn setup(mut commands: Commands) {
 This panics with the following output:
 
 ```text
-thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:206:17
+thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:207:55
 ```
 
 This is because the plugin doesn't know which of the two cameras to use when figuring out
-the values of the `MousePos` and `MousePosWorld` resources. Let's take the panic message's advice.
+the values of the [`MousePos`] and [`MousePosWorld`] resources. Let's take the panic message's advice.
 
 ```rust
     commands.spawn_bundle(Camera2dBundle::default())
@@ -97,18 +97,18 @@ the values of the `MousePos` and `MousePosWorld` resources. Let's take the panic
     commands.spawn_bundle(Camera3dBundle::default());
 ```
 
-If you have multiple cameras with `MainCamera`, the app panics:
+If you have multiple cameras with [`MainCamera`], the app panics:
 
 ```text
 thread 'main' panicked at 'only one camera may be marked with the MainCamera component', src\mouse_pos.rs:209:17
 ```
 
-You should only have a single `MainCamera` in your app.
+You should only have a single [`MainCamera`] in your app.
 
 ### Queries
 
 If you want to get mouse tracking information relative to each camera individually,
-simply [query](bevy::ecs::system::Query) for a `MousePos` or `MousePosWorld` as a
+simply [query](bevy::ecs::system::Query) for a [`MousePos`] or [`MousePosWorld`] as a
 _component_ instead of as a resource.
 
 ```rust
@@ -143,24 +143,24 @@ App::new()
 
 Now, you can add as many cameras as you want, without having to worry about marking any
 of them as the main camera.  
-Note that `MousePos` and `MousePosWorld` will no longer be accessible as global resources
--- you can only access them by `Query`ing camera entities.
+Note that [`MousePos`] and [`MousePosWorld`] will no longer be accessible as global resources
+-- you can only access them by [`Query`](bevy::ecs::system::Query)ing camera entities.
 
 ### Opt-out of tracking for cameras
 
-If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the `ExcludeMouseTracking` component.
+If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the [`ExcludeMouseTracking`] component.
 
 ```rust
 commands.spawn_bundle(Camera2dBundle::default())
     .insert(ExcludeMouseTracking);
 ```
 
-This camera will not have a `MousePos` or a `MousePosWorld`, as it is completely excluded from mouse tracking.
+This camera will not have a [`MousePos`] or a [`MousePosWorld`], as it is completely excluded from mouse tracking.
 
-One reason to do this is because this crate does not currently support cameras with projections other than Bevy's `OrthographicProjection`. If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
+One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::projection::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
 
 ```text
-thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
+thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:159:50
 ```
 
 To get around this, you may choose to have the camera opt-out.
@@ -173,14 +173,6 @@ commands
     })
     .insert(ExcludeMouseTracking);
 ```
-
-If you add the `ExcludeMouseTracking` component to an entity that also has the `MainCamera` component, you will find that the app panics:
-
-```text
-thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeMouseTracking component from the main camera', src\mouse_pos.rs:216:9
-```
-
-You should remove either `ExcludeMouseTracking` or `MainCamera`, as they should not be used together.
 
 ## Mouse motion
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This camera will not have a `MousePos` or a `MousePosWorld`, as it is completely
 One reason to do this is because this crate does not currently support cameras with projections other than Bevy's `OrthographicProjection`. If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
 
 ```text
-thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
+thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
 ```
 
 To get around this, you may choose to have the camera opt-out.
@@ -177,7 +177,7 @@ commands
 If you add the `ExcludeMouseTracking` component to an entity that also has the `MainCamera` component, you will find that the app panics:
 
 ```text
-thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeTracking component from the main camera', src\mouse_pos.rs:216:9
+thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeMouseTracking component from the main camera', src\mouse_pos.rs:216:9
 ```
 
 You should remove either `ExcludeMouseTracking` or `MainCamera`, as they should not be used together.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,14 +175,23 @@
 //!
 //! If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the [`ExcludeMouseTracking`] component.
 //!
-//! ```rust
-//! commands.spawn_bundle(Camera2dBundle::default())
-//!     .insert(ExcludeMouseTracking);
+//! ```
+//! # use bevy::prelude::*;
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, ExcludeMouseTracking};
+//! # App::new()
+//! #   .add_plugins(DefaultPlugins)
+//! #   .add_plugin(MousePosPlugin::SingleCamera)
+//! #   .add_startup_system(setup)
+//! #   .update();
+//! # fn setup(mut commands: Commands) {
+//!     commands.spawn_bundle(Camera2dBundle::default())
+//!         .insert(ExcludeMouseTracking);
+//! # }
 //! ```
 //!
 //! This camera will not have a [`MousePos`] or a [`MousePosWorld`], as it is completely excluded from mouse tracking.
 //!
-//! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::projection::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
+//! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
 //!
 //! ```text
 //! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:159:50
@@ -190,13 +199,21 @@
 //!
 //! To get around this, you may choose to have the camera opt-out.
 //!
-//! ```rust
-//! commands
-//!     .spawn_bundle(Camera2dBundle {
-//!         projection: MyCustomProjection,
+//! ```
+//! # use bevy::prelude::*;
+//! # use bevy::render::camera::{PerspectiveProjection, Projection};
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, ExcludeMouseTracking};
+//! # App::new()
+//! #   .add_plugins(DefaultPlugins)
+//! #   .add_plugin(MousePosPlugin::SingleCamera)
+//! #   .add_startup_system(setup)
+//! #   .update();
+//! # fn setup(mut commands: Commands) {
+//!     commands.spawn_bundle(Camera3dBundle {
+//!         projection: Projection::from(PerspectiveProjection::default()),
 //!         ..default()
-//!     })
-//!     .insert(ExcludeMouseTracking);
+//!     }).insert(ExcludeMouseTracking);
+//! # }
 //! ```
 //!
 //! # Mouse motion

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,14 +111,6 @@
 //! # }
 //! ```
 //!
-//! If you have multiple cameras with [`MainCamera`], the app panics:
-//!
-//! ```text
-//! thread 'main' panicked at 'only one camera may be marked with the MainCamera component', src\mouse_pos.rs:209:17
-//! ```
-//!
-//! You should only have a single [`MainCamera`] in your app.
-//!
 //! ## Queries
 //!
 //! If you want to get mouse tracking information relative to each camera individually,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@
 //! ```
 
 mod mouse_pos;
-pub use mouse_pos::{MainCamera, MousePos, MousePosPlugin, MousePosWorld};
+pub use mouse_pos::{ExcludeTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};
 
 mod mouse_motion;
 pub use mouse_motion::{MouseMotion, MouseMotionPlugin};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,11 +90,11 @@
 //! This panics with the following output:
 //!
 //! ```text
-//! thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:206:17
+//! thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:207:55
 //! ```
 //!
 //! This is because the plugin doesn't know which of the two cameras to use when figuring out
-//! the values of the `MousePos` and `MousePosWorld` resources. Let's take the panic message's advice.
+//! the values of the [`MousePos`] and [`MousePosWorld`] resources. Let's take the panic message's advice.
 //!
 //! ```
 //! # use bevy::prelude::*;
@@ -111,18 +111,18 @@
 //! # }
 //! ```
 //!
-//! If you have multiple cameras with `MainCamera`, the app panics:
+//! If you have multiple cameras with [`MainCamera`], the app panics:
 //!
 //! ```text
 //! thread 'main' panicked at 'only one camera may be marked with the MainCamera component', src\mouse_pos.rs:209:17
 //! ```
 //!
-//! You should only have a single `MainCamera` in your app.
+//! You should only have a single [`MainCamera`] in your app.
 //!
 //! ## Queries
 //!
 //! If you want to get mouse tracking information relative to each camera individually,
-//! simply [query](bevy::ecs::system::Query) for a `MousePos` or `MousePosWorld` as a
+//! simply [query](bevy::ecs::system::Query) for a [`MousePos`] or [`MousePosWorld`] as a
 //! _component_ instead of as a resource.
 //!
 //! ```
@@ -168,24 +168,24 @@
 //!
 //! Now, you can add as many cameras as you want, without having to worry about marking any
 //! of them as the main camera.  
-//! Note that `MousePos` and `MousePosWorld` will no longer be accessible as global resources
-//! -- you can only access them by `Query`ing camera entities.
+//! Note that [`MousePos`] and [`MousePosWorld`] will no longer be accessible as global resources
+//! -- you can only access them by [`Query`](bevy::ecs::system::Query)ing camera entities.
 //!
 //! ## Opt-out of tracking for cameras
 //!
-//! If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the `ExcludeMouseTracking` component.
+//! If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the [`ExcludeMouseTracking`] component.
 //!
 //! ```rust
 //! commands.spawn_bundle(Camera2dBundle::default())
 //!     .insert(ExcludeMouseTracking);
 //! ```
 //!
-//! This camera will not have a `MousePos` or a `MousePosWorld`, as it is completely excluded from mouse tracking.
+//! This camera will not have a [`MousePos`] or a [`MousePosWorld`], as it is completely excluded from mouse tracking.
 //!
-//! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's `OrthographicProjection`. If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
+//! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::projection::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
 //!
 //! ```text
-//! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
+//! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:159:50
 //! ```
 //!
 //! To get around this, you may choose to have the camera opt-out.
@@ -198,14 +198,6 @@
 //!     })
 //!     .insert(ExcludeMouseTracking);
 //! ```
-//!
-//! If you add the `ExcludeMouseTracking` component to an entity that also has the `MainCamera` component, you will find that the app panics:
-//!
-//! ```text
-//! thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeMouseTracking component from the main camera', src\mouse_pos.rs:216:9
-//! ```
-//!
-//! You should remove either `ExcludeMouseTracking` or `MainCamera`, as they should not be used together.
 //!
 //! # Mouse motion
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@
 //! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's `OrthographicProjection`. If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
 //!
 //! ```text
-//! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
+//! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
 //! ```
 //!
 //! To get around this, you may choose to have the camera opt-out.
@@ -202,7 +202,7 @@
 //! If you add the `ExcludeMouseTracking` component to an entity that also has the `MainCamera` component, you will find that the app panics:
 //!
 //! ```text
-//! thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeTracking component from the main camera', src\mouse_pos.rs:216:9
+//! thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeMouseTracking component from the main camera', src\mouse_pos.rs:216:9
 //! ```
 //!
 //! You should remove either `ExcludeMouseTracking` or `MainCamera`, as they should not be used together.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,7 @@
 //! This panics with the following output:
 //!
 //! ```text
-//! thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:163:13
-//! note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+//! thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:206:17
 //! ```
 //!
 //! This is because the plugin doesn't know which of the two cameras to use when figuring out
@@ -111,6 +110,14 @@
 //!     commands.spawn_bundle(Camera3dBundle::default());
 //! # }
 //! ```
+//!
+//! If you have multiple cameras with `MainCamera`, the app panics:
+//!
+//! ```text
+//! thread 'main' panicked at 'only one camera may be marked with the MainCamera component', src\mouse_pos.rs:209:17
+//! ```
+//!
+//! You should only have a single `MainCamera` in your app.
 //!
 //! ## Queries
 //!
@@ -164,6 +171,42 @@
 //! Note that `MousePos` and `MousePosWorld` will no longer be accessible as global resources
 //! -- you can only access them by `Query`ing camera entities.
 //!
+//! ## Opt-out of tracking for cameras
+//!
+//! If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the `ExcludeMouseTracking` component.
+//!
+//! ```rust
+//! commands.spawn_bundle(Camera2dBundle::default())
+//!     .insert(ExcludeMouseTracking);
+//! ```
+//!
+//! This camera will not have a `MousePos` or a `MousePosWorld`, as it is completely excluded from mouse tracking.
+//!
+//! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's `OrthographicProjection`. If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
+//!
+//! ```text
+//! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:148:14
+//! ```
+//!
+//! To get around this, you may choose to have the camera opt-out.
+//!
+//! ```rust
+//! commands
+//!     .spawn_bundle(Camera2dBundle {
+//!         projection: MyCustomProjection,
+//!         ..default()
+//!     })
+//!     .insert(ExcludeMouseTracking);
+//! ```
+//!
+//! If you add the `ExcludeMouseTracking` component to an entity that also has the `MainCamera` component, you will find that the app panics:
+//!
+//! ```text
+//! thread 'main' panicked at 'excluded main camera -- consider removing the ExcludeTracking component from the main camera', src\mouse_pos.rs:216:9
+//! ```
+//!
+//! You should remove either `ExcludeMouseTracking` or `MainCamera`, as they should not be used together.
+//!
 //! # Mouse motion
 //!
 //! This crate supports a resource that tracks mouse motion, via [`MouseMotionPlugin`].
@@ -184,7 +227,7 @@
 //! ```
 
 mod mouse_pos;
-pub use mouse_pos::{ExcludeTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};
+pub use mouse_pos::{ExcludeMouseTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};
 
 mod mouse_motion;
 pub use mouse_motion::{MouseMotion, MouseMotionPlugin};

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -90,12 +90,12 @@ impl Display for MousePos {
     }
 }
 
-type NeedScreenspaceTracking = (Without<MousePos>, Without<ExcludeMouseTracking>);
-type NeedWorldspaceTracking = (Without<MousePosWorld>, Without<ExcludeMouseTracking>);
+type NeedsScreenspaceTracking = (Without<MousePos>, Without<ExcludeMouseTracking>);
+type NeedsWorldspaceTracking = (Without<MousePosWorld>, Without<ExcludeMouseTracking>);
 
 fn add_pos_components(
-    cameras1: Query<(Entity, &Camera), NeedScreenspaceTracking>,
-    cameras2: Query<Entity, (With<Camera>, NeedWorldspaceTracking)>,
+    cameras1: Query<(Entity, &Camera), NeedsScreenspaceTracking>,
+    cameras2: Query<Entity, (With<Camera>, NeedsWorldspaceTracking)>,
     windows: Res<Windows>,
     mut commands: Commands,
 ) {
@@ -167,6 +167,9 @@ fn update_pos_ortho(
 
 /// Marker component for the primary camera in the world.
 /// If only one camera exists, this is optional.
+///
+/// # Notes
+/// If there are multiple `MainCamera`s in the same world, the app will panic.
 #[derive(Debug, Clone, Copy, Component)]
 pub struct MainCamera;
 

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -153,7 +153,7 @@ fn update_pos_ortho(
     for (camera, mut world, screen) in tracking.iter_mut() {
         let (camera, proj) = cameras
             .get(camera)
-            .expect("only orthographic cameras are supported -- consider adding an ExcludeTracking component");
+            .expect("only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component");
         let offset = Vec2::new(proj.left, proj.bottom);
 
         // Must multiply by projection scale before applying camera global transform
@@ -211,9 +211,9 @@ fn find_main_camera(
             Some(main)
         }
     };
-    // panic if the query finds an entity with both MainCamera and ExcludeTracking components
+    // panic if the query finds an entity with both MainCamera and ExcludeMouseTracking components
     if !excluded_main.is_empty() {
-        panic!("excluded main camera -- consider removing the ExcludeTracking component from the main camera")
+        panic!("excluded main camera -- consider removing the ExcludeMouseTracking component from the main camera")
     }
 }
 

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -65,7 +65,7 @@ impl Plugin for MousePosPlugin {
 /// Marker component for cameras to be excluded from tracking.
 /// Any camera with this component will not be given a [`MousePos`] or [`MousePosWorld`] component.
 #[derive(Debug, Clone, Copy, Component)]
-pub struct ExcludeTracking;
+pub struct ExcludeMouseTracking;
 
 /// The location of the mouse in screenspace.  
 /// This will be updated every frame during [`CoreStage::First`]. Any systems that rely
@@ -86,8 +86,8 @@ impl Display for MousePos {
     }
 }
 
-type NeedScreenspaceTracking = (Without<MousePos>, Without<ExcludeTracking>);
-type NeedWorldspaceTracking = (Without<MousePosWorld>, Without<ExcludeTracking>);
+type NeedScreenspaceTracking = (Without<MousePos>, Without<ExcludeMouseTracking>);
+type NeedWorldspaceTracking = (Without<MousePosWorld>, Without<ExcludeMouseTracking>);
 
 fn add_pos_components(
     cameras1: Query<(Entity, &Camera), NeedScreenspaceTracking>,
@@ -148,7 +148,7 @@ impl Deref for MousePosWorld {
 
 fn update_pos_ortho(
     mut tracking: Query<(Entity, &mut MousePosWorld, &MousePos), Changed<MousePos>>,
-    cameras: Query<(&GlobalTransform, &OrthographicProjection), Without<ExcludeTracking>>,
+    cameras: Query<(&GlobalTransform, &OrthographicProjection), Without<ExcludeMouseTracking>>,
 ) {
     for (camera, mut world, screen) in tracking.iter_mut() {
         let (camera, proj) = cameras
@@ -190,7 +190,7 @@ fn main_camera_changed(
 fn find_main_camera(
     mut main_store: ResMut<MainCameraStore>,
     cameras: Query<(Entity, Option<&MainCamera>), With<Camera>>,
-    excluded_main: Query<Entity, (With<MainCamera>, With<ExcludeTracking>)>,
+    excluded_main: Query<Entity, (With<MainCamera>, With<ExcludeMouseTracking>)>,
 ) {
     use bevy::ecs::query::QuerySingleError;
     main_store.0 = match cameras.get_single() {


### PR DESCRIPTION
This PR resolves #18 about incompatible cameras, and possibly other issues that may have come down the line by allowing the user to manually opt-out individual cameras.

ExcludeMouseTracking is a marker component for any camera the user wishes to opt-out of mouse tracking.

By having this marker, a camera will not be given a MousePos or a MousePosWorld, and will also be excluded from the query when update_pos_ortho runs.

If an entity that has a MainCamera component also has an ExcludeTracking component, it will panic with an appropriate error message.

This PR does not allow users to use custom projections and mouse tracking on the same camera, it only allows the app to both have cameras for mouse tracking, and separate cameras with custom projections.