### PR TITLE
Specify main camera with a `Resource`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_mouse_tracking_plugin"
 description = "A plugin for effortless mouse tracking in the bevy game engine."
-version = "0.3.1"
+version = "0.4.0"
 authors = ["JoJoJet <joe102000@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_mouse_tracking_plugin"
 description = "A plugin for effortless mouse tracking in the bevy game engine."
-version = "0.4.0"
+version = "0.3.1"
 authors = ["JoJoJet <joe102000@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -75,10 +75,19 @@ _component_ instead of as a resource.
 
 App::new()
     // plugins omitted...
+    .add_startup_system(setup)
     .add_system(dbg_for_each)
 
+fn setup(mut commands: Commands) {
+    // Spawn the main camera for the game...
+    commands.spawn_bundle(Camera2dBundle::default());
+    // ...as well as a special overhead camera for the minimap.
+    commands.spawn_bundle(MinimapCameraBundle::default());
+}
+
 fn dbg_for_each(mouse_pos: Query<&MousePosWorld>) {
-    // This prints the mouse position for every camera, once per frame.
+    // This prints the mouse position twice every frame:
+    // once relative to the main camera, and once relative to the minimap camera.
     for pos in mouse_pos.iter() {
         eprintln!("{}", *pos);
     }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This will print the world-space location of the mouse on every frame.
 Note that this is only supported for two-dimensional, orthographic cameras,
 but pull requests for 3D support are welcome!
 
-Note that if you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
+If you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
 resources will still exist, but they will always be zero.
 
 ### Queries

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ App::new()
     // plugins omitted...
     .add_startup_system(setup)
     .add_system(dbg_for_each)
+    // ...
 
 fn setup(mut commands: Commands) {
     // Spawn the main camera for the game...
@@ -128,18 +129,16 @@ The motion can be accessed from any system in a [`MouseMotion`] resource.
 
 [`Res`]: bevy::ecs::system::Res
 
+<!-- cargo-rdme end -->
+
 ## Crate name
 
-As a final aside: the name of this crate is intentionally verbose.
-This is because I didn't want to steal a crate name, especially since
-it is very likely that this crate will eventually be made redundant by
-future updates to `bevy`.  
+As a final aside: the name of this crate is intentionally verbose,
+since it is very likely that this crate will eventually be made redundant by future updates to Bevy.  
 I recommend renaming the crate in your `Cargo.toml`:
 ```toml
 [dependencies]
 mouse_tracking = { package = "bevy_mouse_tracking_plugin", version = "..." }
 ```
-
-<!-- cargo-rdme end -->
 
 License: MIT

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera};
 App::new()
     .add_plugins(DefaultPlugins)
     .add_plugin(MousePosPlugin)
+    .add_startup_system(setup)
+    .add_system(dbg_mouse)
     // ...
-    .update();
 
 // Spawn a camera, and specify it as the main camera.
 

--- a/README.md
+++ b/README.md
@@ -20,37 +20,35 @@ This crate also supports more complex use cases such as multiple cameras, which 
 
 ## Basics
 
-First, add the plugin to your app:
-
 ```rust
 use bevy::prelude::*;
-use bevy_mouse_tracking_plugin::MousePosPlugin;
+use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera};
+
+// First, add the plugin to your `App`.
 
 App::new()
     .add_plugins(DefaultPlugins)
-    .add_plugin(MousePosPlugin::SingleCamera);
-```
+    .add_plugin(MousePosPlugin)
+    // ...
+    .update();
 
-Now, you can access the resource in your [`System`]s:
+// Spawn a camera, and specify it as the main camera.
 
-[`System`]: bevy::ecs::system::System
+fn setup(mut commands: Commands) {
+    let camera_id = commands.spawn(Camera2dBundle::default()).id();
+    commands.insert_resource(MainCamera(camera_id));
+}
 
-```rust
+// With that, you can now easily track the main camera through a global resource.
+
 use bevy_mouse_tracking_plugin::MousePos;
 fn dbg_mouse(mouse: Res<MousePos>) {
+    // This will print the screen-space location of the mouse on every frame.
     eprintln!("{}", *mouse);
 }
 ```
-...and don't forget to add the system to your app:
-```rust
-    .add_plugin(MousePosPlugin::SingleCamera)
-    .add_system(dbg_mouse);
 
-```
-
-This will print the screen-space location of the mouse on every frame.
-
-However, we can do better than just screen-space: we support automatic
+We can do better than just screen-space: we support automatic
 transformation to world-space coordinates via the [`MousePosWorld`] resource.
 
 ```rust
@@ -61,82 +59,31 @@ fn dbg_world(mouse: Res<MousePosWorld>) {
 ```
 
 This will print the world-space location of the mouse on every frame.  
-Note that this is only supported for two-dimensional, orthographic camera,
+Note that this is only supported for two-dimensional, orthographic cameras,
 but pull requests for 3D support are welcome!
 
-## Multiple cameras
-
-You may notice that if you try to use this plugin in an app that has multiple cameras, it crashes!
-
-```rust
-
-App::new()
-    .add_plugins(DefaultPlugins)
-    .add_plugin(MousePosPlugin::SingleCamera)
-    .add_startup_system(setup)
-    .run();
-
-fn setup(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle::default());
-    commands.spawn_bundle(Camera3dBundle::default());
-}
-```
-
-This panics with the following output:
-
-```text
-thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:207:55
-```
-
-This is because the plugin doesn't know which of the two cameras to use when figuring out
-the values of the [`MousePos`] and [`MousePosWorld`] resources. Let's take the panic message's advice.
-
-```rust
-    commands.spawn_bundle(Camera2dBundle::default())
-        .insert(MainCamera); // added this line
-    commands.spawn_bundle(Camera3dBundle::default());
-```
+Note that if you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
+resources will still exist, but they will always be zero.
 
 ### Queries
 
 If you want to get mouse tracking information relative to each camera individually,
-simply [query](bevy::ecs::system::Query) for a [`MousePos`] or [`MousePosWorld`] as a
+simply [query](bevy::ecs::system::Query) for `MousePos` or `MousePosWorld` as a
 _component_ instead of as a resource.
 
 ```rust
 
 App::new()
     // plugins omitted...
-    .add_system(dbg_for_each);
+    .add_system(dbg_for_each)
 
 fn dbg_for_each(mouse_pos: Query<&MousePosWorld>) {
+    // This prints the mouse position for every camera, once per frame.
     for pos in mouse_pos.iter() {
-        // This prints the mouse position twice per frame:
-        // once relative to the UI camera, and once relative to the physical camera.
         eprintln!("{}", *pos);
     }
 }
 ```
-
-### No main camera
-
-Let's say you have multiple cameras in your app, and you want to treat them all equally,
-without declaring any one of them as the main camera.  
-Change the plugin to this:
-
-```rust
-App::new()
-    .add_plugins(DefaultPlugins)
-    .add_plugin(MousePosPlugin::MultiCamera) // SingleCamera -> MultiCamera
-    .add_startup_system(setup)
-    // ...
-
-```
-
-Now, you can add as many cameras as you want, without having to worry about marking any
-of them as the main camera.  
-Note that [`MousePos`] and [`MousePosWorld`] will no longer be accessible as global resources
--- you can only access them by [`Query`](bevy::ecs::system::Query)ing camera entities.
 
 ### Opt-out of tracking for cameras
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ App::new()
 // Spawn a camera, and specify it as the main camera.
 
 fn setup(mut commands: Commands) {
-    let camera_id = commands.spawn(Camera2dBundle::default()).id();
+    let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
     commands.insert_resource(MainCamera(camera_id));
 }
 

--- a/examples/screen.rs
+++ b/examples/screen.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use bevy_mouse_tracking_plugin::{MousePos, MousePosPlugin};
+use bevy_mouse_tracking_plugin::{MainCamera, MousePos, MousePosPlugin};
 
 #[derive(Component)]
 struct Cursor;
@@ -13,7 +13,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(WindowDescriptor::default())
-        .add_plugin(MousePosPlugin::SingleCamera)
+        .add_plugin(MousePosPlugin)
         .add_startup_system(setup)
         .add_system(bevy::window::close_on_esc)
         .add_system(run)
@@ -22,7 +22,8 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<WindowDescriptor>) {
     // Spawn a Camera
-    commands.spawn_bundle(Camera2dBundle::default());
+    let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
+    commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin
     commands.spawn_bundle(SpriteBundle {

--- a/examples/world.rs
+++ b/examples/world.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use bevy_mouse_tracking_plugin::{MousePos, MousePosPlugin, MousePosWorld};
+use bevy_mouse_tracking_plugin::{MainCamera, MousePos, MousePosPlugin, MousePosWorld};
 
 #[derive(Component)]
 struct Cursor;
@@ -13,7 +13,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(WindowDescriptor::default())
-        .add_plugin(MousePosPlugin::SingleCamera)
+        .add_plugin(MousePosPlugin)
         .add_startup_system(setup)
         .add_system(bevy::window::close_on_esc)
         .add_system(run)
@@ -24,7 +24,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<Win
     // Spawn a Camera
     let mut camera_bundle = Camera2dBundle::default();
     camera_bundle.projection.scale = 0.5; // works fine with non-unit scaling.
-    commands.spawn_bundle(camera_bundle);
+    let camera_id = commands.spawn_bundle(camera_bundle).id();
+    commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin
     commands.spawn_bundle(SpriteBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! // Spawn a camera, and specify it as the main camera.
 //!
 //! fn setup(mut commands: Commands) {
-//!     let camera_id = commands.spawn(Camera2dBundle::default()).id();
+//!     let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
 //!     commands.insert_resource(MainCamera(camera_id));
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,10 @@
 //! App::new()
 //!     .add_plugins(DefaultPlugins)
 //!     .add_plugin(MousePosPlugin)
-//! #    .add_startup_system(setup)
-//! #    .add_system(dbg_mouse)
+//!     .add_startup_system(setup)
+//!     .add_system(dbg_mouse)
 //!     // ...
-//!     .update();
+//! #    .update();
 //!
 //! // Spawn a camera, and specify it as the main camera.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,18 +152,6 @@
 //! The motion can be accessed from any system in a [`MouseMotion`] resource.
 //!
 //! [`Res`]: bevy::ecs::system::Res
-//!
-//! # Crate name
-//!
-//! As a final aside: the name of this crate is intentionally verbose.
-//! This is because I didn't want to steal a crate name, especially since
-//! it is very likely that this crate will eventually be made redundant by
-//! future updates to `bevy`.  
-//! I recommend renaming the crate in your `Cargo.toml`:
-//! ```toml
-//! [dependencies]
-//! mouse_tracking = { package = "bevy_mouse_tracking_plugin", version = "..." }
-//! ```
 
 mod mouse_pos;
 pub use mouse_pos::{ExcludeMouseTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,43 +16,37 @@
 //!
 //! # Basics
 //!
-//! First, add the plugin to your app:
-//!
 //! ```
 //! use bevy::prelude::*;
-//! use bevy_mouse_tracking_plugin::MousePosPlugin;
+//! use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera};
+//!
+//! // First, add the plugin to your `App`.
 //!
 //! App::new()
 //!     .add_plugins(DefaultPlugins)
-//!     .add_plugin(MousePosPlugin::SingleCamera);
-//! ```
+//!     .add_plugin(MousePosPlugin)
+//! #    .add_startup_system(setup)
+//! #    .add_system(dbg_mouse)
+//!     // ...
+//!     .update();
 //!
-//! Now, you can access the resource in your [`System`]s:
+//! // Spawn a camera, and specify it as the main camera.
 //!
-//! [`System`]: bevy::ecs::system::System
+//! fn setup(mut commands: Commands) {
+//!     let camera_id = commands.spawn(Camera2dBundle::default()).id();
+//!     commands.insert_resource(MainCamera(camera_id));
+//! }
 //!
-//! ```
-//! # use bevy::prelude::*;
+//! // With that, you can now easily track the main camera through a global resource.
+//!
 //! use bevy_mouse_tracking_plugin::MousePos;
 //! fn dbg_mouse(mouse: Res<MousePos>) {
+//!     // This will print the screen-space location of the mouse on every frame.
 //!     eprintln!("{}", *mouse);
 //! }
 //! ```
-//! ...and don't forget to add the system to your app:
-//! ```
-//! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::MousePosPlugin;
-//! # App::new()
-//! #   .add_plugins(DefaultPlugins)
-//!     .add_plugin(MousePosPlugin::SingleCamera)
-//!     .add_system(dbg_mouse);
 //!
-//! # fn dbg_mouse() { }
-//! ```
-//!
-//! This will print the screen-space location of the mouse on every frame.
-//!
-//! However, we can do better than just screen-space: we support automatic
+//! We can do better than just screen-space: we support automatic
 //! transformation to world-space coordinates via the [`MousePosWorld`] resource.
 //!
 //! ```
@@ -64,57 +58,16 @@
 //! ```
 //!
 //! This will print the world-space location of the mouse on every frame.  
-//! Note that this is only supported for two-dimensional, orthographic camera,
+//! Note that this is only supported for two-dimensional, orthographic cameras,
 //! but pull requests for 3D support are welcome!
 //!
-//! # Multiple cameras
-//!
-//! You may notice that if you try to use this plugin in an app that has multiple cameras, it crashes!
-//!
-//! ```should_panic
-//! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::MousePosPlugin;
-//!
-//! App::new()
-//!     .add_plugins(DefaultPlugins)
-//!     .add_plugin(MousePosPlugin::SingleCamera)
-//!     .add_startup_system(setup)
-//!     .run();
-//!
-//! fn setup(mut commands: Commands) {
-//!     commands.spawn_bundle(Camera2dBundle::default());
-//!     commands.spawn_bundle(Camera3dBundle::default());
-//! }
-//! ```
-//!
-//! This panics with the following output:
-//!
-//! ```text
-//! thread 'main' panicked at 'cannot identify main camera -- consider adding the MainCamera component to one of the cameras', src\mouse_pos.rs:207:55
-//! ```
-//!
-//! This is because the plugin doesn't know which of the two cameras to use when figuring out
-//! the values of the [`MousePos`] and [`MousePosWorld`] resources. Let's take the panic message's advice.
-//!
-//! ```
-//! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera};
-//! # App::new()
-//! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin::SingleCamera)
-//! #   .add_startup_system(setup)
-//! #   .update();
-//! # fn setup(mut commands: Commands) {
-//!     commands.spawn_bundle(Camera2dBundle::default())
-//!         .insert(MainCamera); // added this line
-//!     commands.spawn_bundle(Camera3dBundle::default());
-//! # }
-//! ```
+//! Note that if you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
+//! resources will still exist, but they will always be zero.
 //!
 //! ## Queries
 //!
 //! If you want to get mouse tracking information relative to each camera individually,
-//! simply [query](bevy::ecs::system::Query) for a [`MousePos`] or [`MousePosWorld`] as a
+//! simply [query](bevy::ecs::system::Query) for `MousePos` or `MousePosWorld` as a
 //! _component_ instead of as a resource.
 //!
 //! ```
@@ -124,44 +77,17 @@
 //! App::new()
 //!     // plugins omitted...
 //! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin::SingleCamera)
-//!     .add_system(dbg_for_each);
+//! #   .add_plugin(MousePosPlugin)
+//!     .add_system(dbg_for_each)
+//! #    .update();
 //!
 //! fn dbg_for_each(mouse_pos: Query<&MousePosWorld>) {
+//!     // This prints the mouse position for every camera, once per frame.
 //!     for pos in mouse_pos.iter() {
-//!         // This prints the mouse position twice per frame:
-//!         // once relative to the UI camera, and once relative to the physical camera.
 //!         eprintln!("{}", *pos);
 //!     }
 //! }
 //! ```
-//!
-//! ## No main camera
-//!
-//! Let's say you have multiple cameras in your app, and you want to treat them all equally,
-//! without declaring any one of them as the main camera.  
-//! Change the plugin to this:
-//!
-//! ```
-//! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin};
-//! App::new()
-//!     .add_plugins(DefaultPlugins)
-//!     .add_plugin(MousePosPlugin::MultiCamera) // SingleCamera -> MultiCamera
-//!     .add_startup_system(setup)
-//!     // ...
-//! #   .update();
-//!
-//! # fn setup(mut commands: Commands) {
-//! #   commands.spawn_bundle(Camera2dBundle::default());
-//! #   commands.spawn_bundle(Camera2dBundle::default());
-//! # }
-//! ```
-//!
-//! Now, you can add as many cameras as you want, without having to worry about marking any
-//! of them as the main camera.  
-//! Note that [`MousePos`] and [`MousePosWorld`] will no longer be accessible as global resources
-//! -- you can only access them by [`Query`](bevy::ecs::system::Query)ing camera entities.
 //!
 //! ## Opt-out of tracking for cameras
 //!
@@ -172,7 +98,7 @@
 //! # use bevy_mouse_tracking_plugin::{MousePosPlugin, ExcludeMouseTracking};
 //! # App::new()
 //! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin::SingleCamera)
+//! #   .add_plugin(MousePosPlugin)
 //! #   .add_startup_system(setup)
 //! #   .update();
 //! # fn setup(mut commands: Commands) {
@@ -197,7 +123,7 @@
 //! # use bevy_mouse_tracking_plugin::{MousePosPlugin, ExcludeMouseTracking};
 //! # App::new()
 //! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin::SingleCamera)
+//! #   .add_plugin(MousePosPlugin)
 //! #   .add_startup_system(setup)
 //! #   .update();
 //! # fn setup(mut commands: Commands) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@
 //! #   .add_plugin(MousePosPlugin)
 //!     .add_startup_system(setup)
 //!     .add_system(dbg_for_each)
+//!     // ...
 //! #    .update();
 //!
 //! # type MinimapCameraBundle = Camera2dBundle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //!     .add_system(dbg_for_each)
 //! #    .update();
 //!
-//! # type MinimapCameraBundle = Camera2dBundle::default();
+//! # type MinimapCameraBundle = Camera2dBundle;
 //! fn setup(mut commands: Commands) {
 //!     // Spawn the main camera for the game...
 //!     commands.spawn_bundle(Camera2dBundle::default());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! Note that this is only supported for two-dimensional, orthographic cameras,
 //! but pull requests for 3D support are welcome!
 //!
-//! Note that if you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
+//! If you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
 //! resources will still exist, but they will always be zero.
 //!
 //! ## Queries

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,11 +78,22 @@
 //!     // plugins omitted...
 //! #   .add_plugins(DefaultPlugins)
 //! #   .add_plugin(MousePosPlugin)
+//!     .add_startup_system(setup)
 //!     .add_system(dbg_for_each)
 //! #    .update();
 //!
+//! # type MinimapCameraBundle = Camera2dBundle::default();
+//! fn setup(mut commands: Commands) {
+//!     // Spawn the main camera for the game...
+//!     commands.spawn_bundle(Camera2dBundle::default());
+//!     // ...as well as a special overhead camera for the minimap.
+//!     commands.spawn_bundle(MinimapCameraBundle::default());
+//! }
+//!
 //! fn dbg_for_each(mouse_pos: Query<&MousePosWorld>) {
-//!     // This prints the mouse position for every camera, once per frame.
+//!     // This prints the mouse position twice every frame:
+//!     // once relative to the main camera, and once relative to the minimap camera.
+//!     # // FIXME: We should take camera-driven rendering into account somehow.
 //!     for pos in mouse_pos.iter() {
 //!         eprintln!("{}", *pos);
 //!     }


### PR DESCRIPTION
Previously, the main camera was specified by adding a marker component to the camera entity. This was ergonomic for the end user, but this meant we had to deal with looking up the main camera all the time and deal with many edge cases.

Specifying it with a resource is slightly less ergonomic, but makes invalid states impossible, meaning we no longer need to deal with (or document) edge cases.

Partial implementation of #20.

# Migration Guide

Before:

```rust
commands.spawn_bundle(Camera2dBundle::default()).insert(MainCamera);
```

After:

```rust
let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
commands.insert_resource(MainCamera(camera_id));
```