### PR TITLE
Make mouse tracking components opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This crate also supports more complex use cases such as multiple cameras, which 
 
 ```rust
 use bevy::prelude::*;
-use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera};
+use bevy_mouse_tracking_plugin::MousePosPlugin;
 
 // First, add the plugin to your `App`.
 
@@ -33,94 +33,92 @@ App::new()
     .add_system(dbg_mouse)
     // ...
 
-// Spawn a camera, and specify it as the main camera.
+use bevy_mouse_tracking_plugin::MousePos;
 
 fn setup(mut commands: Commands) {
-    let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
+    commands
+        // Spawn a camera bundle
+        .spawn_bundle(Camera2dBundle::default())
+        // Opt in to mouse tracking
+        .insert(MousePos::default());
+}
+
+// Now, we can track the mouse position by querying for it.
+
+fn dbg_mouse(mouse: Query<&MousePos>) {
+    // This will print the screen-space location of the mouse on every frame.
+    eprintln!("{}", *mouse.single());
+    // If we did `mouse.iter()` instead, this will naturally work for multiple cameras.
+}
+```
+
+Having to call `Query::single` is a bit annoying, and potentially error-prone.
+Instead, we can specify a main camera, which the plugin will treat specially.
+
+```rust
+use bevy_mouse_tracking_plugin::MainCamera;
+
+fn setup(mut commands: Commands) {
+    let camera_id = commands
+        // Spawn a camera bundle
+        .spawn_bundle(Camera2dBundle::default())
+        // Opt in to mouse tracking
+        .insert(MousePos::default())
+        // Get the ID of the camera entity we just spawned
+        .id();
+
+    // Define the `MainCamera` resource.
     commands.insert_resource(MainCamera(camera_id));
 }
 
-// With that, you can now easily track the main camera through a global resource.
+// Now that we've specified the main camera, we can get the mouse position using a global resource.
 
-use bevy_mouse_tracking_plugin::MousePos;
 fn dbg_mouse(mouse: Res<MousePos>) {
     // This will print the screen-space location of the mouse on every frame.
     eprintln!("{}", *mouse);
 }
 ```
 
+## World-space
+
 We can do better than just screen-space: we support automatic
-transformation to world-space coordinates via the [`MousePosWorld`] resource.
+transformation to world-space coordinates via [`MousePosWorld`]
+-- this is can be accessed as either a component or a resource.
 
 ```rust
-use bevy_mouse_tracking_plugin::MousePosWorld;
-fn dbg_world(mouse: Res<MousePosWorld>) {
+use bevy_mouse_tracking_plugin::MainCamera;
+
+fn setup(mut commands: Commands) {
+    let camera_id = commands
+        // Spawn a camera bundle
+        .spawn_bundle(Camera2dBundle::default())
+        // Opt in to mouse tracking
+        .insert(MousePos::default())
+        .insert(MousePosWorld::default())
+        // Get the ID of the camera entity we just spawned
+        .id();
+
+    // Define the `MainCamera` resource.
+    commands.insert_resource(MainCamera(camera_id));
+}
+
+// Now that we've specified the main camera, we can get the mouse position using a global resource.
+
+fn dbg_world_single(mouse: Query<&MousePosWorld>) {
+    // This will print the world-space location of the mouse on every frame.
+    eprintln!("{}", *mouse.single());
+}
+
+fn dbg_world_res(mouse: Res<MousePosWorld>) {
     eprintln!("{}", *mouse);
 }
 ```
 
-This will print the world-space location of the mouse on every frame.  
 Note that this is only supported for two-dimensional, orthographic cameras,
 but pull requests for 3D support are welcome!
 
 If you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
 resources will still exist, but they will always be zero.
-
-### Queries
-
-If you want to get mouse tracking information relative to each camera individually,
-simply [query](bevy::ecs::system::Query) for `MousePos` or `MousePosWorld` as a
-_component_ instead of as a resource.
-
-```rust
-
-App::new()
-    // plugins omitted...
-    .add_startup_system(setup)
-    .add_system(dbg_for_each)
-    // ...
-
-fn setup(mut commands: Commands) {
-    // Spawn the main camera for the game...
-    commands.spawn_bundle(Camera2dBundle::default());
-    // ...as well as a special overhead camera for the minimap.
-    commands.spawn_bundle(MinimapCameraBundle::default());
-}
-
-fn dbg_for_each(mouse_pos: Query<&MousePosWorld>) {
-    // This prints the mouse position twice every frame:
-    // once relative to the main camera, and once relative to the minimap camera.
-    for pos in mouse_pos.iter() {
-        eprintln!("{}", *pos);
-    }
-}
-```
-
-### Opt-out of tracking for cameras
-
-If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the [`ExcludeMouseTracking`] component.
-
-```rust
-    commands.spawn_bundle(Camera2dBundle::default())
-        .insert(ExcludeMouseTracking);
-```
-
-This camera will not have a [`MousePos`] or a [`MousePosWorld`], as it is completely excluded from mouse tracking.
-
-One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
-
-```text
-thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:159:50
-```
-
-To get around this, you may choose to have the camera opt-out.
-
-```rust
-    commands.spawn_bundle(Camera3dBundle {
-        projection: Projection::from(PerspectiveProjection::default()),
-        ..default()
-    }).insert(ExcludeMouseTracking);
-```
 
 ## Mouse motion
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,9 @@ use bevy_mouse_tracking_plugin::MainCamera;
 
 fn setup(mut commands: Commands) {
     let camera_id = commands
-        // Spawn a camera bundle
-        .spawn_bundle(Camera2dBundle::default())
-        // Opt in to mouse tracking
-        .insert(MousePos::default())
-        // Get the ID of the camera entity we just spawned
+        // Spawn a camera bundle, etc.
+        // ...
+        // Get the ID of the camera entity we just spawned.
         .id();
 
     // Define the `MainCamera` resource.
@@ -86,29 +84,25 @@ transformation to world-space coordinates via [`MousePosWorld`]
 -- this is can be accessed as either a component or a resource.
 
 ```rust
-use bevy_mouse_tracking_plugin::MainCamera;
+use bevy_mouse_tracking_plugin::MousePosWorld;
 
 fn setup(mut commands: Commands) {
-    let camera_id = commands
-        // Spawn a camera bundle
-        .spawn_bundle(Camera2dBundle::default())
-        // Opt in to mouse tracking
+        // Spawn camera bundle, etc.
+        // ...
+        // Opt in to mouse tracking.
         .insert(MousePos::default())
         .insert(MousePosWorld::default())
-        // Get the ID of the camera entity we just spawned
-        .id();
-
-    // Define the `MainCamera` resource.
-    commands.insert_resource(MainCamera(camera_id));
+        // Get the ID, define main camera resource, etc.
+        // ...
 }
 
-// Now that we've specified the main camera, we can get the mouse position using a global resource.
-
+// Getting the world-space position using a query.
 fn dbg_world_single(mouse: Query<&MousePosWorld>) {
-    // This will print the world-space location of the mouse on every frame.
+    // This will print the world-space position of the mouse on every frame.
     eprintln!("{}", *mouse.single());
 }
 
+// Getting it using the resource.
 fn dbg_world_res(mouse: Res<MousePosWorld>) {
     eprintln!("{}", *mouse);
 }

--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@
 [![bevy_mouse_tracking on crates.io](https://img.shields.io/crates/v/bevy_mouse_tracking_plugin.svg)](https://crates.io/crates/bevy_mouse_tracking_plugin)
 [![bevy_mouse_tracking docs](https://img.shields.io/badge/docs-docs.rs-orange.svg)](https://docs.rs/bevy_mouse_tracking_plugin)
 
-Tracking the mouse in `bevy` is kind of annoying.
-You gotta use [`Events`], and [`EventReader`]s, and even then, they only
-get called when the mouse actually *moves*.
+This crate aims to make mouse tracking both effortless and explicit.
+Tracking is opt-in and handled opaquely by this plugin.
 
-[`Events`]: bevy::ecs::event::Events
-[`EventReader`]: bevy::ecs::event::EventReader
-
-This crate aims to make this as easy as possible, by providing a
-static [resource](bevy::ecs::system::Res) that tracks the mouse position every frame.
-
-This crate also supports more complex use cases such as multiple cameras, which are discussed further down.
+The mouse can be tracked on a per-camera basis by querying for tracking components.
+Additionally, a global resource is maintained that tracks the main camera, if applicable.
 
 ## Basics
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ transformation to world-space coordinates via [`MousePosWorld`]
 use bevy_mouse_tracking_plugin::MousePosWorld;
 
 fn setup(mut commands: Commands) {
+    let camera_id = commands
         // ...
         // Opt in to mouse tracking.
         // Adding `MousePosWorld` will automatically add `MousePos`.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ use bevy_mouse_tracking_plugin::MainCamera;
 
 fn setup(mut commands: Commands) {
     let camera_id = commands
-        // Spawn a camera bundle, etc.
-        // ...
+        // ...spawn a camera bundle, etc.
+        //
         // Get the ID of the camera entity we just spawned.
         .id();
 
@@ -87,10 +87,9 @@ transformation to world-space coordinates via [`MousePosWorld`]
 use bevy_mouse_tracking_plugin::MousePosWorld;
 
 fn setup(mut commands: Commands) {
-        // Spawn camera bundle, etc.
         // ...
         // Opt in to mouse tracking.
-        .insert(MousePos::default())
+        // Adding `MousePosWorld` will automatically add `MousePos`.
         .insert(MousePosWorld::default())
         // Get the ID, define main camera resource, etc.
         // ...

--- a/examples/screen.rs
+++ b/examples/screen.rs
@@ -22,7 +22,10 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<WindowDescriptor>) {
     // Spawn a Camera
-    let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
+    let camera_id = commands
+        .spawn_bundle(Camera2dBundle::default())
+        .insert(MousePos::default())
+        .id();
     commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin

--- a/examples/world.rs
+++ b/examples/world.rs
@@ -24,7 +24,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<Win
     // Spawn a Camera
     let mut camera_bundle = Camera2dBundle::default();
     camera_bundle.projection.scale = 0.5; // works fine with non-unit scaling.
-    let camera_id = commands.spawn_bundle(camera_bundle).id();
+    let camera_id = commands
+        .spawn_bundle(camera_bundle)
+        .insert(MousePos::default())
+        .insert(MousePosWorld::default())
+        .id();
     commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin

--- a/examples/world.rs
+++ b/examples/world.rs
@@ -26,7 +26,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<Win
     camera_bundle.projection.scale = 0.5; // works fine with non-unit scaling.
     let camera_id = commands
         .spawn_bundle(camera_bundle)
-        .insert(MousePos::default())
         .insert(MousePosWorld::default())
         .id();
     commands.insert_resource(MainCamera(camera_id));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@
 //! [`Res`]: bevy::ecs::system::Res
 
 mod mouse_pos;
-pub use mouse_pos::{ExcludeMouseTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};
+pub use mouse_pos::{MainCamera, MousePos, MousePosPlugin, MousePosWorld};
 
 mod mouse_motion;
 pub use mouse_motion::{MouseMotion, MouseMotionPlugin};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use bevy::prelude::*;
-//! use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera};
+//! use bevy_mouse_tracking_plugin::MousePosPlugin;
 //!
 //! // First, add the plugin to your `App`.
 //!
@@ -30,121 +30,109 @@
 //!     // ...
 //! #    .update();
 //!
-//! // Spawn a camera, and specify it as the main camera.
+//! use bevy_mouse_tracking_plugin::MousePos;
 //!
 //! fn setup(mut commands: Commands) {
-//!     let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
+//!     commands
+//!         // Spawn a camera bundle
+//!         .spawn_bundle(Camera2dBundle::default())
+//!         // Opt in to mouse tracking
+//!         .insert(MousePos::default());
+//! }
+//!
+//! // Now, we can track the mouse position by querying for it.
+//!
+//! fn dbg_mouse(mouse: Query<&MousePos>) {
+//!     // This will print the screen-space location of the mouse on every frame.
+//!     eprintln!("{}", *mouse.single());
+//!     // If we did `mouse.iter()` instead, this will naturally work for multiple cameras.
+//! }
+//! ```
+//!
+//! Having to call `Query::single` is a bit annoying, and potentially error-prone.
+//! Instead, we can specify a main camera, which the plugin will treat specially.
+//!
+//! ```
+//! # use bevy::prelude::*;
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos, MainCamera};
+//! # App::new()
+//! #    .add_plugins(DefaultPlugins)
+//! #    .add_plugin(MousePosPlugin)
+//! #    .add_startup_system(setup)
+//! #    .add_system(dbg_mouse)
+//! #    .update();
+//! use bevy_mouse_tracking_plugin::MainCamera;
+//!
+//! fn setup(mut commands: Commands) {
+//!     let camera_id = commands
+//!         // Spawn a camera bundle
+//!         .spawn_bundle(Camera2dBundle::default())
+//!         // Opt in to mouse tracking
+//!         .insert(MousePos::default())
+//!         // Get the ID of the camera entity we just spawned
+//!         .id();
+//!
+//!     // Define the `MainCamera` resource.
 //!     commands.insert_resource(MainCamera(camera_id));
 //! }
 //!
-//! // With that, you can now easily track the main camera through a global resource.
+//! // Now that we've specified the main camera, we can get the mouse position using a global resource.
 //!
-//! use bevy_mouse_tracking_plugin::MousePos;
 //! fn dbg_mouse(mouse: Res<MousePos>) {
 //!     // This will print the screen-space location of the mouse on every frame.
 //!     eprintln!("{}", *mouse);
 //! }
 //! ```
 //!
+//! # World-space
+//!
 //! We can do better than just screen-space: we support automatic
-//! transformation to world-space coordinates via the [`MousePosWorld`] resource.
+//! transformation to world-space coordinates via [`MousePosWorld`]
+//! -- this is can be accessed as either a component or a resource.
 //!
 //! ```
 //! # use bevy::prelude::*;
-//! use bevy_mouse_tracking_plugin::MousePosWorld;
-//! fn dbg_world(mouse: Res<MousePosWorld>) {
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos, MainCamera};
+//! # App::new()
+//! #    .add_plugins(DefaultPlugins)
+//! #    .add_plugin(MousePosPlugin)
+//! #    .add_startup_system(setup)
+//! #    .add_system(dbg_world_single)
+//! #    .add_system(dbg_world_res)
+//! #    .update();
+//! use bevy_mouse_tracking_plugin::MainCamera;
+//!
+//! fn setup(mut commands: Commands) {
+//!     let camera_id = commands
+//!         // Spawn a camera bundle
+//!         .spawn_bundle(Camera2dBundle::default())
+//!         // Opt in to mouse tracking
+//!         .insert(MousePos::default())
+//!         .insert(MousePosWorld::default())
+//!         // Get the ID of the camera entity we just spawned
+//!         .id();
+//!
+//!     // Define the `MainCamera` resource.
+//!     commands.insert_resource(MainCamera(camera_id));
+//! }
+//!
+//! // Now that we've specified the main camera, we can get the mouse position using a global resource.
+//!
+//! fn dbg_world_single(mouse: Query<&MousePosWorld>) {
+//!     // This will print the world-space location of the mouse on every frame.
+//!     eprintln!("{}", *mouse.single());
+//! }
+//!
+//! fn dbg_world_res(mouse: Res<MousePosWorld>) {
 //!     eprintln!("{}", *mouse);
 //! }
 //! ```
 //!
-//! This will print the world-space location of the mouse on every frame.  
 //! Note that this is only supported for two-dimensional, orthographic cameras,
 //! but pull requests for 3D support are welcome!
 //!
 //! If you do not specify a [`MainCamera`] resource, the [`MousePos`] and [`MousePosWorld`]
 //! resources will still exist, but they will always be zero.
-//!
-//! ## Queries
-//!
-//! If you want to get mouse tracking information relative to each camera individually,
-//! simply [query](bevy::ecs::system::Query) for `MousePos` or `MousePosWorld` as a
-//! _component_ instead of as a resource.
-//!
-//! ```
-//! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MainCamera, MousePosWorld};
-//!
-//! App::new()
-//!     // plugins omitted...
-//! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin)
-//!     .add_startup_system(setup)
-//!     .add_system(dbg_for_each)
-//!     // ...
-//! #    .update();
-//!
-//! # type MinimapCameraBundle = Camera2dBundle;
-//! fn setup(mut commands: Commands) {
-//!     // Spawn the main camera for the game...
-//!     commands.spawn_bundle(Camera2dBundle::default());
-//!     // ...as well as a special overhead camera for the minimap.
-//!     commands.spawn_bundle(MinimapCameraBundle::default());
-//! }
-//!
-//! fn dbg_for_each(mouse_pos: Query<&MousePosWorld>) {
-//!     // This prints the mouse position twice every frame:
-//!     // once relative to the main camera, and once relative to the minimap camera.
-//!     # // FIXME: We should take camera-driven rendering into account somehow.
-//!     for pos in mouse_pos.iter() {
-//!         eprintln!("{}", *pos);
-//!     }
-//! }
-//! ```
-//!
-//! ## Opt-out of tracking for cameras
-//!
-//! If you wish to have a camera be excluded from mouse tracking for whatever reason, you may give it the [`ExcludeMouseTracking`] component.
-//!
-//! ```
-//! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, ExcludeMouseTracking};
-//! # App::new()
-//! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin)
-//! #   .add_startup_system(setup)
-//! #   .update();
-//! # fn setup(mut commands: Commands) {
-//!     commands.spawn_bundle(Camera2dBundle::default())
-//!         .insert(ExcludeMouseTracking);
-//! # }
-//! ```
-//!
-//! This camera will not have a [`MousePos`] or a [`MousePosWorld`], as it is completely excluded from mouse tracking.
-//!
-//! One reason to do this is because this crate does not currently support cameras with projections other than Bevy's [`OrthographicProjection`](bevy::render::camera::OrthographicProjection). If you use such a camera, even if you don't use it for tracking mouse position, you will find that it panics:
-//!
-//! ```text
-//! thread 'main' panicked at 'only orthographic cameras are supported -- consider adding an ExcludeMouseTracking component: QueryDoesNotMatch(5v0)', src\mouse_pos.rs:159:50
-//! ```
-//!
-//! To get around this, you may choose to have the camera opt-out.
-//!
-//! ```
-//! # use bevy::prelude::*;
-//! # use bevy::render::camera::{PerspectiveProjection, Projection};
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, ExcludeMouseTracking};
-//! # App::new()
-//! #   .add_plugins(DefaultPlugins)
-//! #   .add_plugin(MousePosPlugin)
-//! #   .add_startup_system(setup)
-//! #   .update();
-//! # fn setup(mut commands: Commands) {
-//!     commands.spawn_bundle(Camera3dBundle {
-//!         projection: Projection::from(PerspectiveProjection::default()),
-//!         ..default()
-//!     }).insert(ExcludeMouseTracking);
-//! # }
-//! ```
 //!
 //! # Mouse motion
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! ```
 //! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos, MainCamera};
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos};
 //! # App::new()
 //! #    .add_plugins(DefaultPlugins)
 //! #    .add_plugin(MousePosPlugin)
@@ -65,11 +65,11 @@
 //!
 //! fn setup(mut commands: Commands) {
 //!     let camera_id = commands
-//!         // Spawn a camera bundle
-//!         .spawn_bundle(Camera2dBundle::default())
-//!         // Opt in to mouse tracking
-//!         .insert(MousePos::default())
-//!         // Get the ID of the camera entity we just spawned
+//!         // Spawn a camera bundle, etc.
+//! #        .spawn_bundle(Camera2dBundle::default())
+//! #        .insert(MousePos::default())
+//!         // ...
+//!         // Get the ID of the camera entity we just spawned.
 //!         .id();
 //!
 //!     // Define the `MainCamera` resource.
@@ -100,29 +100,29 @@
 //! #    .add_system(dbg_world_single)
 //! #    .add_system(dbg_world_res)
 //! #    .update();
-//! use bevy_mouse_tracking_plugin::MainCamera;
+//! use bevy_mouse_tracking_plugin::MousePosWorld;
 //!
 //! fn setup(mut commands: Commands) {
-//!     let camera_id = commands
-//!         // Spawn a camera bundle
-//!         .spawn_bundle(Camera2dBundle::default())
-//!         // Opt in to mouse tracking
+//! #    let camera_id = commands
+//! #        .spawn_bundle(Camera2dBundle::default())
+//!         // Spawn camera bundle, etc.
+//!         // ...
+//!         // Opt in to mouse tracking.
 //!         .insert(MousePos::default())
 //!         .insert(MousePosWorld::default())
-//!         // Get the ID of the camera entity we just spawned
-//!         .id();
-//!
-//!     // Define the `MainCamera` resource.
-//!     commands.insert_resource(MainCamera(camera_id));
+//!         // Get the ID, define main camera resource, etc.
+//!         // ...
+//! #        .id();
+//! #    commands.insert_resource(MainCamera(camera_id));
 //! }
 //!
-//! // Now that we've specified the main camera, we can get the mouse position using a global resource.
-//!
+//! // Getting the world-space position using a query.
 //! fn dbg_world_single(mouse: Query<&MousePosWorld>) {
-//!     // This will print the world-space location of the mouse on every frame.
+//!     // This will print the world-space position of the mouse on every frame.
 //!     eprintln!("{}", *mouse.single());
 //! }
 //!
+//! // Getting it using the resource.
 //! fn dbg_world_res(mouse: Res<MousePosWorld>) {
 //!     eprintln!("{}", *mouse);
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,10 @@
 //!
 //! fn setup(mut commands: Commands) {
 //!     let camera_id = commands
-//!         // Spawn a camera bundle, etc.
+//!         // ...spawn a camera bundle, etc.
 //! #        .spawn_bundle(Camera2dBundle::default())
 //! #        .insert(MousePos::default())
-//!         // ...
+//!         //
 //!         // Get the ID of the camera entity we just spawned.
 //!         .id();
 //!
@@ -105,10 +105,9 @@
 //! fn setup(mut commands: Commands) {
 //! #    let camera_id = commands
 //! #        .spawn_bundle(Camera2dBundle::default())
-//!         // Spawn camera bundle, etc.
 //!         // ...
 //!         // Opt in to mouse tracking.
-//!         .insert(MousePos::default())
+//!         // Adding `MousePosWorld` will automatically add `MousePos`.
 //!         .insert(MousePosWorld::default())
 //!         // Get the ID, define main camera resource, etc.
 //!         // ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@
 //! use bevy_mouse_tracking_plugin::MousePosWorld;
 //!
 //! fn setup(mut commands: Commands) {
-//! #    let camera_id = commands
+//!     let camera_id = commands
 //! #        .spawn_bundle(Camera2dBundle::default())
 //!         // ...
 //!         // Opt in to mouse tracking.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,11 @@
 //! [![bevy_mouse_tracking on crates.io](https://img.shields.io/crates/v/bevy_mouse_tracking_plugin.svg)](https://crates.io/crates/bevy_mouse_tracking_plugin)
 //! [![bevy_mouse_tracking docs](https://img.shields.io/badge/docs-docs.rs-orange.svg)](https://docs.rs/bevy_mouse_tracking_plugin)
 //!
-//! Tracking the mouse in `bevy` is kind of annoying.
-//! You gotta use [`Events`], and [`EventReader`]s, and even then, they only
-//! get called when the mouse actually *moves*.
+//! This crate aims to make mouse tracking both effortless and explicit.
+//! Tracking is opt-in and handled opaquely by this plugin.
 //!
-//! [`Events`]: bevy::ecs::event::Events
-//! [`EventReader`]: bevy::ecs::event::EventReader
-//!
-//! This crate aims to make this as easy as possible, by providing a
-//! static [resource](bevy::ecs::system::Res) that tracks the mouse position every frame.
-//!
-//! This crate also supports more complex use cases such as multiple cameras, which are discussed further down.
+//! The mouse can be tracked on a per-camera basis by querying for tracking components.
+//! Additionally, a global resource is maintained that tracks the main camera, if applicable.
 //!
 //! # Basics
 //!

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -7,6 +7,9 @@ pub struct MousePosPlugin;
 
 impl Plugin for MousePosPlugin {
     fn build(&self, app: &mut App) {
+        app.add_startup_system_to_stage(StartupStage::PostStartup, add_dependent_pos);
+        app.add_system_to_stage(CoreStage::Last, add_dependent_pos);
+
         app.add_system_to_stage(CoreStage::First, update_pos);
         app.add_system_to_stage(CoreStage::First, update_pos_ortho.after(update_pos));
 
@@ -48,6 +51,15 @@ fn update_pos(
         {
             pos.0 = position;
         }
+    }
+}
+
+fn add_dependent_pos(
+    needs_screen_pos: Query<Entity, (With<MousePosWorld>, Without<MousePos>)>,
+    mut commands: Commands,
+) {
+    for id in &needs_screen_pos {
+        commands.entity(id).insert(MousePos::default());
     }
 }
 


### PR DESCRIPTION
Second part of #20

The plugin will not track the mouse for a camera, unless the respective `MousePos{World}` components are added.

Future work: Currently, mouse tracking components are all zero when the game starts, until you move the mouse. Fix this.