### PR TITLE
Command-driven initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additionally, a global resource is maintained that tracks the main camera, if ap
 
 ```rust
 use bevy::prelude::*;
-use bevy_mouse_tracking_plugin::MousePosPlugin;
+use bevy_mouse_tracking_plugin::{MousePosPlugin, InsertExt as _};
 
 // First, add the plugin to your `App`.
 
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands) {
         // Spawn a camera bundle
         .spawn_bundle(Camera2dBundle::default())
         // Opt in to mouse tracking
-        .insert(MousePos::default());
+        .add_mouse_tracking();
 }
 
 // Now, we can track the mouse position by querying for it.
@@ -83,9 +83,9 @@ use bevy_mouse_tracking_plugin::MousePosWorld;
 fn setup(mut commands: Commands) {
     let camera_id = commands
         // ...
-        // Opt in to mouse tracking.
-        // Adding `MousePosWorld` will automatically add `MousePos`.
-        .insert(MousePosWorld::default())
+        // Opt in to world-space mouse tracking.
+        // This will automatically opt into screen-space tracking.
+        .add_world_tracking()
         // Get the ID, define main camera resource, etc.
         // ...
 }

--- a/examples/screen.rs
+++ b/examples/screen.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use bevy_mouse_tracking_plugin::{MainCamera, MousePos, MousePosPlugin};
+use bevy_mouse_tracking_plugin::{AddMouseTracking, MainCamera, MousePos, MousePosPlugin};
 
 #[derive(Component)]
 struct Cursor;
@@ -22,10 +22,8 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<WindowDescriptor>) {
     // Spawn a Camera
-    let camera_id = commands
-        .spawn_bundle(Camera2dBundle::default())
-        .insert(MousePos::default())
-        .id();
+    let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
+    commands.add(AddMouseTracking::new(camera_id));
     commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin

--- a/examples/screen.rs
+++ b/examples/screen.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use bevy_mouse_tracking_plugin::{AddMouseTracking, MainCamera, MousePos, MousePosPlugin};
+use bevy_mouse_tracking_plugin::{InsertExt as _, MainCamera, MousePos, MousePosPlugin};
 
 #[derive(Component)]
 struct Cursor;
@@ -22,8 +22,10 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<WindowDescriptor>) {
     // Spawn a Camera
-    let camera_id = commands.spawn_bundle(Camera2dBundle::default()).id();
-    commands.add(AddMouseTracking::new(camera_id));
+    let camera_id = commands
+        .spawn_bundle(Camera2dBundle::default())
+        .add_mouse_tracking()
+        .id();
     commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin

--- a/examples/world.rs
+++ b/examples/world.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use bevy_mouse_tracking_plugin::{
-    AddWorldTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld,
+    InsertExt as _, MainCamera, MousePos, MousePosPlugin, MousePosWorld,
 };
 
 #[derive(Component)]
@@ -26,8 +26,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<Win
     // Spawn a Camera
     let mut camera_bundle = Camera2dBundle::default();
     camera_bundle.projection.scale = 0.5; // works fine with non-unit scaling.
-    let camera_id = commands.spawn_bundle(camera_bundle).id();
-    commands.add(AddWorldTracking::new(camera_id));
+    let camera_id = commands
+        .spawn_bundle(camera_bundle)
+        .add_world_tracking()
+        .id();
     commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin

--- a/examples/world.rs
+++ b/examples/world.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 
-use bevy_mouse_tracking_plugin::{MainCamera, MousePos, MousePosPlugin, MousePosWorld};
+use bevy_mouse_tracking_plugin::{
+    AddWorldTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld,
+};
 
 #[derive(Component)]
 struct Cursor;
@@ -24,10 +26,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, window: Res<Win
     // Spawn a Camera
     let mut camera_bundle = Camera2dBundle::default();
     camera_bundle.projection.scale = 0.5; // works fine with non-unit scaling.
-    let camera_id = commands
-        .spawn_bundle(camera_bundle)
-        .insert(MousePosWorld::default())
-        .id();
+    let camera_id = commands.spawn_bundle(camera_bundle).id();
+    commands.add(AddWorldTracking::new(camera_id));
     commands.insert_resource(MainCamera(camera_id));
 
     // Reference for the origin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,8 @@
 
 mod mouse_pos;
 pub use mouse_pos::{
-    AddMouseTracking, AddWorldTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld,
+    AddMouseTracking, AddWorldTracking, InsertExt, MainCamera, MousePos, MousePosPlugin,
+    MousePosWorld,
 };
 
 mod mouse_motion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```
 //! use bevy::prelude::*;
-//! use bevy_mouse_tracking_plugin::MousePosPlugin;
+//! use bevy_mouse_tracking_plugin::{MousePosPlugin, InsertExt as _};
 //!
 //! // First, add the plugin to your `App`.
 //!
@@ -31,7 +31,7 @@
 //!         // Spawn a camera bundle
 //!         .spawn_bundle(Camera2dBundle::default())
 //!         // Opt in to mouse tracking
-//!         .insert(MousePos::default());
+//!         .add_mouse_tracking();
 //! }
 //!
 //! // Now, we can track the mouse position by querying for it.
@@ -48,7 +48,7 @@
 //!
 //! ```
 //! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos};
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos, InsertExt};
 //! # App::new()
 //! #    .add_plugins(DefaultPlugins)
 //! #    .add_plugin(MousePosPlugin)
@@ -61,7 +61,7 @@
 //!     let camera_id = commands
 //!         // ...spawn a camera bundle, etc.
 //! #        .spawn_bundle(Camera2dBundle::default())
-//! #        .insert(MousePos::default())
+//! #        .add_mouse_tracking()
 //!         //
 //!         // Get the ID of the camera entity we just spawned.
 //!         .id();
@@ -86,7 +86,7 @@
 //!
 //! ```
 //! # use bevy::prelude::*;
-//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos, MainCamera};
+//! # use bevy_mouse_tracking_plugin::{MousePosPlugin, MousePos, MainCamera, InsertExt};
 //! # App::new()
 //! #    .add_plugins(DefaultPlugins)
 //! #    .add_plugin(MousePosPlugin)
@@ -100,9 +100,9 @@
 //!     let camera_id = commands
 //! #        .spawn_bundle(Camera2dBundle::default())
 //!         // ...
-//!         // Opt in to mouse tracking.
-//!         // Adding `MousePosWorld` will automatically add `MousePos`.
-//!         .insert(MousePosWorld::default())
+//!         // Opt in to world-space mouse tracking.
+//!         // This will automatically opt into screen-space tracking.
+//!         .add_world_tracking()
 //!         // Get the ID, define main camera resource, etc.
 //!         // ...
 //! #        .id();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,9 @@
 //! [`Res`]: bevy::ecs::system::Res
 
 mod mouse_pos;
-pub use mouse_pos::{AddMouseTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};
+pub use mouse_pos::{
+    AddMouseTracking, AddWorldTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld,
+};
 
 mod mouse_motion;
 pub use mouse_motion::{MouseMotion, MouseMotionPlugin};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@
 //! [`Res`]: bevy::ecs::system::Res
 
 mod mouse_pos;
-pub use mouse_pos::{MainCamera, MousePos, MousePosPlugin, MousePosWorld};
+pub use mouse_pos::{AddMouseTracking, MainCamera, MousePos, MousePosPlugin, MousePosWorld};
 
 mod mouse_motion;
 pub use mouse_motion::{MouseMotion, MouseMotionPlugin};

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -7,9 +7,6 @@ pub struct MousePosPlugin;
 
 impl Plugin for MousePosPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system_to_stage(StartupStage::PostStartup, add_dependent_pos);
-        app.add_system_to_stage(CoreStage::Last, add_dependent_pos);
-
         app.add_system_to_stage(CoreStage::First, update_pos);
         app.add_system_to_stage(CoreStage::First, update_pos_ortho.after(update_pos));
 
@@ -103,15 +100,6 @@ fn update_pos(
         {
             pos.0 = position;
         }
-    }
-}
-
-fn add_dependent_pos(
-    needs_screen_pos: Query<Entity, (With<MousePosWorld>, Without<MousePos>)>,
-    mut commands: Commands,
-) {
-    for id in &needs_screen_pos {
-        commands.add(AddMouseTracking::new(id));
     }
 }
 

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -25,7 +25,19 @@ impl Plugin for MousePosPlugin {
 
 /// Extension trait for [`EntityCommands`] and [`EntityMut`] that allows adding mouse tracking to a camera entity.
 pub trait InsertExt {
+    /// Adds the mouse tracking component [`MousePos`] to this entity, with a correct initial value.
+    ///
+    /// # Panics
+    /// * If the current entity does not have a [`Camera`] component.
+    /// * If there is a camera, but it does not render to a window.
     fn add_mouse_tracking(&mut self) -> &mut Self;
+    /// Adds the mouse tracking component [`MousePosWorld`] to this entity, with a correct initial value.
+    /// It is unnecessary to call both this method and [`add_mouse_tracking`](#method.add_mouse_tracking).
+    ///
+    /// # Panics
+    /// * If the current entity does not have a [`Camera`] component.
+    /// * If there is a camera, but it does not render to a window.
+    /// * If the camera does not have an [`OrthographicProjection`] component.
     fn add_world_tracking(&mut self) -> &mut Self;
 }
 
@@ -175,6 +187,8 @@ impl Deref for MousePosWorld {
 
 /// A [`Command`] that adds the component [`MousePosWorld`] to an entity, with a correct initial position.
 /// For more details, see the docs for [`AddMouseTracking`].
+///
+/// Executing this command automatically executes `AddMouseTracking`.
 pub struct AddWorldTracking(Entity);
 
 impl AddWorldTracking {

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -44,7 +44,7 @@ impl Display for MousePos {
 /// The simplest way to enable mouse tracking for a camera is to add the component `MousePos::default`
 /// -- however, doing this means that the initial value for the cursor position will be zero. This command handles that automatically.
 ///
-/// To add both `MousePos` and [`MousePosWorld`], consider using `AddWorldTracking`.
+/// To add both `MousePos` and [`MousePosWorld`], consider using [`AddWorldTracking`].
 pub struct AddMouseTracking(Entity);
 
 impl AddMouseTracking {
@@ -70,9 +70,7 @@ impl Command for AddMouseTracking {
         #[track_caller]
         #[cold]
         fn no_window(window: impl std::fmt::Debug) -> ! {
-            panic!(
-                "tried to call the command `AddMouseTracking` on a camera ({window:?}) that renders to an image",
-            )
+            panic!("could not find the window '{window:?}'")
         }
 
         let camera_id = self.0;
@@ -120,7 +118,7 @@ fn add_dependent_pos(
 /// The location of the mouse in worldspace.  
 /// This will be updated every frame during [`CoreStage::First`]. Any systems that rely
 /// on this should come after `CoreStage::First`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Component)]
+#[derive(Debug, Clone, Copy, PartialEq, Component)]
 pub struct MousePosWorld(Vec3);
 
 impl Display for MousePosWorld {
@@ -137,6 +135,42 @@ impl Deref for MousePosWorld {
     }
 }
 
+/// A [`Command`] that adds the component [`MousePosWorld`] to an entity, with a correct initial position.
+/// For more details, see the docs for [`AddMouseTracking`].
+pub struct AddWorldTracking(Entity);
+
+impl AddWorldTracking {
+    pub fn new(id: Entity) -> Self {
+        Self(id)
+    }
+}
+
+impl Command for AddWorldTracking {
+    fn write(self, world: &mut World) {
+        fn no_transform(id: impl std::fmt::Debug) -> ! {
+            panic!("tried to call the command `AddWorldTracking` on a camera ({id:?}) with no `GlobalTransform`")
+        }
+        fn no_proj(id: impl std::fmt::Debug) -> ! {
+            panic!("tried to call the command `AddWorldTracking` on a camera ({id:?}) with no `OrthographicProjection`")
+        }
+
+        let camera_id = self.0;
+
+        AddMouseTracking(camera_id).write(world);
+
+        let camera = world.entity(camera_id);
+        let screen_pos = camera.get::<MousePos>().unwrap();
+        let transform = camera
+            .get::<GlobalTransform>()
+            .unwrap_or_else(|| no_transform(camera_id));
+        let proj = camera
+            .get::<OrthographicProjection>()
+            .unwrap_or_else(|| no_proj(camera_id));
+        let world_pos = compute_world_pos_ortho(screen_pos.0, transform, proj);
+        world.entity_mut(camera_id).insert(MousePosWorld(world_pos));
+    }
+}
+
 fn update_pos_ortho(
     mut tracking: Query<(Entity, &mut MousePosWorld, &MousePos), Changed<MousePos>>,
     cameras: Query<(&GlobalTransform, &OrthographicProjection)>,
@@ -145,12 +179,19 @@ fn update_pos_ortho(
         let (camera, proj) = cameras
             .get(camera)
             .expect("only orthographic cameras are supported");
-        let offset = Vec2::new(proj.left, proj.bottom);
-
-        // Must multiply by projection scale before applying camera global transform
-        // Otherwise you get weird offset mouse positions when both scaling and panning the camera.
-        world.0 = camera.mul_vec3(((screen.0 + offset) * proj.scale).extend(0.0));
+        world.0 = compute_world_pos_ortho(screen.0, camera, proj);
     }
+}
+
+fn compute_world_pos_ortho(
+    screen_pos: Vec2,
+    transform: &GlobalTransform,
+    proj: &OrthographicProjection,
+) -> Vec3 {
+    let offset = Vec2::new(proj.left, proj.bottom);
+    // Must multiply by projection scale before applying camera global transform
+    // Otherwise you get weird offset mouse positions when both scaling and panning the camera.
+    transform.mul_vec3(((screen_pos + offset) * proj.scale).extend(0.0))
 }
 
 /// Resource that specifies the main camera. If this resource is not defined, all cameras will be treated equally.
@@ -171,7 +212,7 @@ fn update_resources(
         // If the main camera was unset since last frame, zero out the resources.
         if *main_defined_last_frame {
             *screen_res = MousePos(default());
-            *world_res = MousePosWorld::default();
+            *world_res = MousePosWorld(default());
             *main_defined_last_frame = false;
         }
         return;


### PR DESCRIPTION
## Objective

When you first initialize a mouse tracking component, it will have a zero value until you first move the mouse.

## Solution

Remove the `Default` impl for mouse tracking components. Instead, initialize them using commands.