### PR TITLE
Add explicit ordering of crate resource updating systems after Bevy e…

### DIFF
--- a/src/mouse_motion.rs
+++ b/src/mouse_motion.rs
@@ -8,7 +8,10 @@ pub use bevy::input::mouse::MouseMotion;
 impl bevy::app::Plugin for MouseMotionPlugin {
     fn build(&self, app: &mut bevy::app::App) {
         app.insert_resource(MouseMotion { delta: Vec2::ZERO });
-        app.add_system_to_stage(CoreStage::First, update_mouse_motion);
+        app.add_system_to_stage(
+            CoreStage::First,
+            update_mouse_motion.after(Events::<MouseMotion>::update_system),
+        );
     }
 }
 

--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -14,7 +14,10 @@ pub struct MousePosPlugin;
 
 impl Plugin for MousePosPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_to_stage(CoreStage::First, update_pos);
+        app.add_system_to_stage(
+            CoreStage::First,
+            update_pos.after(Events::<CursorMoved>::update_system),
+        );
         app.add_system_to_stage(CoreStage::First, update_pos_ortho.after(update_pos));
 
         app.insert_resource(MousePos(default()));


### PR DESCRIPTION
Objective
As presented in issue #24, there is a 1 frame lag with mouse tracking.

Solution
This PR adds explicit ordering between the mouse tracking systems in this crate and the event updating systems in Bevy.