### PR TITLE
fix computation of MousePosWorld by flipping y-coord

### DIFF
--- a/src/mouse_pos.rs
+++ b/src/mouse_pos.rs
@@ -226,7 +226,7 @@ fn compute_world_pos_ortho(
     let offset = Vec2::new(proj.left, proj.top);
     // Must multiply by projection scale before applying camera global transform
     // Otherwise you get weird offset mouse positions when both scaling and panning the camera.
-    transform * ((screen_pos + offset) * proj.scale).extend(0.0)
+    transform * (((screen_pos + offset) * proj.scale) * Vec2::new(1.0, -1.0)).extend(0.0)
 }
 
 /// Marker component for the main camera. If no main camera is specified, all cameras will be treated equally.


### PR DESCRIPTION
[y-axis of cursor position was flipped in 0.9](https://bevyengine.org/learn/book/migration-guides/0.8-0.9/#change-ui-coordinate-system-to-have-origin-at-top-left-corner) making y-axis of MosePosWorld the negative of the actual value. Multiplying the Vec2 result of `compute_world_pos_ortho` by `Vec2::new(1.0, -1.0)` does the trick

I've tested it in my own project that depends on this crate