### PR TITLE
Fix `MouseMotion` resource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_mouse_tracking_plugin"
 description = "A plugin for effortless mouse tracking in the bevy game engine."
-version = "0.5.2"
+version = "0.5.3"
 authors = ["JoJoJet <joe102000@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/examples/screen.rs
+++ b/examples/screen.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use bevy_mouse_tracking_plugin::{prelude::*, MainCamera, MousePos};
+use bevy_mouse_tracking_plugin::{prelude::*, MainCamera, MouseMotion, MousePos};
 
 #[derive(Component)]
 struct Cursor;
@@ -13,6 +13,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugin(MousePosPlugin)
+        .add_plugin(MouseMotionPlugin)
         .add_startup_system(setup)
         .add_system(bevy::window::close_on_esc)
         .add_system(run)
@@ -61,8 +62,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, windows: Res<Wi
     ));
 }
 
-fn run(mouse_pos: Res<MousePos>, mut hud_text: Query<&mut Text, With<Hud>>) {
-    let hud_value = format!("Mouse: ({}, {})", mouse_pos.x, mouse_pos.y,);
+fn run(
+    mouse_pos: Res<MousePos>,
+    mouse_motion: Res<MouseMotion>,
+    mut hud_text: Query<&mut Text, With<Hud>>,
+) {
+    let hud_value = format!(
+        "Mouse: ({}, {})\nDelta: ({}, {})",
+        mouse_pos.x, mouse_pos.y, mouse_motion.delta.x, mouse_motion.delta.y,
+    );
 
     if let Some(mut hud_text) = hud_text.iter_mut().next() {
         hud_text.sections.first_mut().unwrap().value = hud_value;

--- a/src/mouse_motion.rs
+++ b/src/mouse_motion.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+use bevy::input::mouse::MouseMotion as BevyMouseMotion;
+
 /// Plugin that tracks mouse motion.
 pub struct MouseMotionPlugin;
 
@@ -19,7 +21,7 @@ impl bevy::app::Plugin for MouseMotionPlugin {
     }
 }
 
-fn update_mouse_motion(mut events: EventReader<MouseMotion>, mut res: ResMut<MouseMotion>) {
+fn update_mouse_motion(mut events: EventReader<BevyMouseMotion>, mut res: ResMut<MouseMotion>) {
     let delta = events.iter().fold(Vec2::ZERO, |acc, e| acc + e.delta);
     *res = MouseMotion { delta };
 }


### PR DESCRIPTION
Fixes #39.

The `MouseMotion` resource did not get properly updated due to a mixup between `bevy_input::MouseMotion` and `bevy_mouse_tracking::MouseMotion`.

This mixup has been fixed. One of the examples has been modified to make use of `MouseMotion`, to prevent future regressions.